### PR TITLE
Fix rust_smbclient_sys crate use

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,3 @@ pub mod smbc;
 pub use crate::{error::*, smbc::*};
 
 pub use crate::parser::*;
-extern crate rust_smbclient_sys;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,4 @@ pub mod smbc;
 pub use crate::{error::*, smbc::*};
 
 pub use crate::parser::*;
+extern crate rust_smbclient_sys;

--- a/src/smbc.rs
+++ b/src/smbc.rs
@@ -980,9 +980,9 @@ impl Smbc {
     ///
     /// @return         return a new Smbc context with user authentication
     ///                 set by set_data (or default). Error should it fail.
-    pub fn new_with_auth(level: u32) -> SmbcResult<Smbc> {
+    pub fn new_with_auth(level: i32) -> SmbcResult<Smbc> {
         unsafe {
-            smbc_init(Some(Self::set_data_wrapper), level as i32);
+            smbc_init(Some(Self::set_data_wrapper), level);
             let ctx = check_mut_ptr(smbc_new_context())?;
             smbc_setOptionDebugToStderr(ctx, 1);
             smbc_setOptionUserData(ctx, Self::auth_wrapper as *mut c_void);
@@ -1009,7 +1009,7 @@ impl Smbc {
                                                wg.as_ptr() as *const c_char,
                                                un.as_ptr() as *const c_char,
                                                pw.as_ptr() as *const c_char);
-            smbc_setDebug(ctx, level as i32);
+            smbc_setDebug(ctx, level);
             let ptr: *mut SMBCCTX = match check_mut_ptr(smbc_init_context(ctx)) {
                 Ok(p) => p,
                 Err(e) => {

--- a/src/smbc.rs
+++ b/src/smbc.rs
@@ -16,7 +16,7 @@ use chrono::*;
 use libc::{c_char, c_int, mode_t, off_t, strncpy, EINVAL};
 use nix::{fcntl::OFlag, sys::stat::Mode};
 use nom::types::CompleteByteSlice;
-use smbclient_sys::*;
+use rust_smbclient_sys::*;
 
 use bitflags::bitflags;
 use lazy_static::*;


### PR DESCRIPTION
	- Crate was renamed but not renamed in wrapper code

cc @cholcombe973 